### PR TITLE
Updated requirements and README.md to use python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,21 @@ Notably, we show that time series analysis (e.g., forecasting) can be cast as ye
 </p>
 
 ## Requirements
-- accelerate==0.20.3
+Use python 3.11 from MiniConda
+
+- torch==2.2.2
+- accelerate==0.28.0
 - einops==0.7.0
 - matplotlib==3.7.0
 - numpy==1.23.5
 - pandas==1.5.3
 - scikit_learn==1.2.2
-- scipy==1.5.4
-- torch==2.0.1
+- scipy==1.12.0
 - tqdm==4.65.0
 - peft==0.4.0
 - transformers==4.31.0
-- deepspeed==0.13.0
+- deepspeed==0.14.0
+- sentencepiece==0.2.0
 
 To install all dependencies:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
-accelerate==0.20.3
+torch==2.2.2
+accelerate==0.28.0
 einops==0.7.0
 matplotlib==3.7.0
 numpy==1.23.5
 pandas==1.5.3
 scikit_learn==1.2.2
-scipy==1.5.4
-torch==2.0.1
+scipy==1.12.0
 tqdm==4.65.0
 peft==0.4.0
 transformers==4.31.0
-deepspeed==0.13.0
+deepspeed==0.14.0
+sentencepiece==0.2.0


### PR DESCRIPTION
I've tested this python 3.11 configuration on my home system:

Ubuntu 22.04 LTS
python 3.11
CUDA 12.2

This is in response to https://github.com/KimMeen/Time-LLM/issues/54#issuecomment-2029209072